### PR TITLE
Pin probdiffeq's version to <0.2.0

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -26,5 +26,5 @@ pandas
 seaborn
 scikit-learn
 tensorflow-probability[jax]
-probdiffeq
+probdiffeq<0.2.0
 diffeqzoo


### PR DESCRIPTION
Hi! :)

This PR pins probdiffeq's version in requirements.txt to <0.2.

Why? Because probdiffeq's next release (which will be 0.2.0) will introduce a few breaking changes, and until I find the time to update the corresponding notebook here, pinning the version number would keep the ODE solver tutorial functional by preserving the status quo.

What do you think? 
