### PR TITLE
Add notebook execution cache and seaborn dependency

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -27,6 +27,14 @@ jobs:
         run: |
           pip install -r requirements.txt
 
+      - name: Cache notebook execution
+        uses: actions/cache@v4
+        with:
+          path: book/_build/execute
+          key: myst-execute-${{ runner.os }}-${{ hashFiles('book/**/*.md', 'requirements.txt') }}
+          restore-keys: |
+            myst-execute-${{ runner.os }}-
+
       - name: Build the book
         env:
           BASE_URL: /${{ github.event.repository.name }}

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -21,6 +21,14 @@ jobs:
         run: |
           pip install -r requirements.txt
 
+      - name: Cache notebook execution
+        uses: actions/cache@v4
+        with:
+          path: book/_build/execute
+          key: myst-execute-${{ runner.os }}-${{ hashFiles('book/**/*.md', 'requirements.txt') }}
+          restore-keys: |
+            myst-execute-${{ runner.os }}-
+
       - name: Build the book
         run: |
           cd book && jupyter book build --execute --html

--- a/requirements.txt
+++ b/requirements.txt
@@ -23,6 +23,7 @@ numpyro
 optax
 pandas
 scikit-learn
+seaborn
 tfp-nightly[jax]
 probdiffeq
 diffeqzoo


### PR DESCRIPTION
## Summary

- Add `actions/cache` step to both `test.yml` and `publish.yml` to cache MyST notebook execution results in `book/_build/execute/`. Unchanged notebooks won't be re-executed on subsequent CI runs, matching the caching behaviour from Jupyter Book v1.
- Add `seaborn` to `requirements.txt`

## Cache key strategy

Cache is keyed on `hashFiles('book/**/*.md', 'requirements.txt')` so it busts when any notebook source or dependency changes. A prefix restore key (`myst-execute-${{ runner.os }}-`) allows partial cache hits when only some notebooks change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)