### PR TITLE
rename: blackjax.low_rank_window_adaptation → blackjax.window_adaptation_low_rank (post-blackjax#923)

### DIFF
--- a/book/algorithms/low_rank_mass_matrix.md
+++ b/book/algorithms/low_rank_mass_matrix.md
@@ -88,7 +88,7 @@ def run_nuts(logdensity_fn, init_params, rng_key, *,
     n_grad  : total gradient evaluations across all chains (warmup + sampling)
     """
     if adaptation == "low_rank":
-        warmup = blackjax.low_rank_window_adaptation(
+        warmup = blackjax.window_adaptation_low_rank(
             blackjax.nuts, logdensity_fn, max_rank=max_rank
         )
     else:


### PR DESCRIPTION
## Summary

One-line follow-up to [blackjax PR #923](https://github.com/blackjax-devs/blackjax/pull/923) (merged 2026-05-20 at `a8998469`), which renamed `blackjax.low_rank_window_adaptation` → `blackjax.window_adaptation_low_rank` without keeping a deprecation alias.

Sampling-book has a single usage at `book/algorithms/low_rank_mass_matrix.md:91`. Updated to the new name so the notebook remains executable on current blackjax/main.

## Why no deprecation alias upstream

The function landed recently (post-#917, 2026-05-18) — few external integrations have hardcoded the old name. Downstream audit confirmed sampling-book had only this one call site; tuningfork wraps the function under its own name (`window_adaptation_low_rank_imm`). The simpler hard rename was preferred over a transition with an alias + deprecation warning.

## Test plan

- [ ] CI: notebook execution succeeds (sphinx build / nb-execute)
- [ ] CI: no `AttributeError: module 'blackjax' has no attribute 'low_rank_window_adaptation'`

🤖 Generated with [Claude Code](https://claude.com/claude-code)
