### PR TITLE
Strip stderr from rendered output (fixes tqdm frame accumulation on published pages)

### DIFF
--- a/book/myst.yml
+++ b/book/myst.yml
@@ -1,6 +1,8 @@
 version: 1
 project:
   title: The Sampling Book Project
+  settings:
+    output_stderr: remove
   authors:
     - name: The Blackjax Team
   exclude:


### PR DESCRIPTION
## Problem

https://blackjax-devs.github.io/sampling-book/algorithms/mclmc/ shows ~20 accumulated tqdm progress frames per sampling cell. Live frontends (terminal, JupyterLab) interpret tqdm's carriage returns and overwrite in place; mystmd's HTML export renders every captured `\r` frame as its own line. Ecosystem-wide tqdm-in-docs problem — the right fix is at the renderer.

## Fix

One line: mystmd's project-level `settings: output_stderr: remove` — strips stderr stream outputs at render time. stdout and cell results are untouched. Book-wide, so every current and future chapter using `blackjax.progress_bar()` (or anything else writing to stderr) renders clean without per-cell `remove-stderr` tags.

## Verification

Minimal throwaway myst project with a synthetic CR-frame cell, built with and without the setting:
- without: 6 raw frames → 8 occurrences in rendered content (reproduces the published symptom)
- with: **zero** stderr frames in rendered content; `print()` output preserved

The PR build (executes all notebooks) is the full-book gate.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_015JsMap6KJUCBNadh5M1FsX